### PR TITLE
Fix dependency for python3.7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -107,11 +107,11 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.0"
-description = "Backported and Experimental Type Hints for Python 3.5+"
+version = "4.2.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
@@ -129,7 +129,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "9d9e42a70976c0a94eb34d843f19b2f69926e500e11bb477db3c245a01c241eb"
+content-hash = "b95fcf3c774a2a194aa795a243c87dd35d1b53ae6d1b48c5c68c5389899467eb"
 
 [metadata.files]
 autopep8 = [
@@ -193,9 +193,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
-    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
-    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
+    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ pydantic = "^1.8.2"
 requests = "^2.25.1"
 python-dotenv = "^0.18.0"
 tinydb = "^4.5.1"
+typing-extensions = "^4.2.0"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.5.7"

--- a/python_fb_page_insights_client/fb_page_insight.py
+++ b/python_fb_page_insights_client/fb_page_insight.py
@@ -1,5 +1,9 @@
 from datetime import datetime, timedelta
-from typing import Any, List, Optional, Union, Dict, Tuple, Literal
+from typing import Any, List, Optional, Union, Dict, Tuple
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from pydantic import BaseModel, BaseSettings, Field, validator
 from enum import Enum, auto, IntEnum


### PR DESCRIPTION
Fix typing dependency for python3.7
Currently, pycontw airflow is using python3.7 env, so some typing will not supported than cause import error